### PR TITLE
geom_alt props

### DIFF
--- a/data/421/171/051/421171051.geojson
+++ b/data/421/171/051/421171051.geojson
@@ -248,6 +248,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1459008880,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"691010dbfe26ddf548b9e57055d41cd6",
     "wof:hierarchy":[
         {
@@ -258,7 +261,7 @@
         }
     ],
     "wof:id":421171051,
-    "wof:lastmodified":1566666588,
+    "wof:lastmodified":1582352009,
     "wof:name":"Bulawayo",
     "wof:parent_id":85681121,
     "wof:placetype":"county",

--- a/data/421/190/261/421190261.geojson
+++ b/data/421/190/261/421190261.geojson
@@ -475,6 +475,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1459009652,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3935070626fec092b443cfcf26da76e6",
     "wof:hierarchy":[
         {
@@ -485,7 +488,7 @@
         }
     ],
     "wof:id":421190261,
-    "wof:lastmodified":1566666585,
+    "wof:lastmodified":1582352009,
     "wof:name":"Harare Urban",
     "wof:parent_id":85681097,
     "wof:placetype":"county",

--- a/data/421/201/479/421201479.geojson
+++ b/data/421/201/479/421201479.geojson
@@ -572,6 +572,9 @@
     ],
     "wof:country":"ZW",
     "wof:created":1459010074,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81999419659c6702b82df68718d89bbc",
     "wof:hierarchy":[
         {
@@ -582,7 +585,7 @@
         }
     ],
     "wof:id":421201479,
-    "wof:lastmodified":1566666586,
+    "wof:lastmodified":1582352009,
     "wof:name":"Harare",
     "wof:parent_id":85681097,
     "wof:placetype":"locality",

--- a/data/856/322/43/85632243.geojson
+++ b/data/856/322/43/85632243.geojson
@@ -910,7 +910,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -988,7 +987,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1582352006,
+    "wof:lastmodified":1583232525,
     "wof:name":"Zimbabwe",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/322/43/85632243.geojson
+++ b/data/856/322/43/85632243.geojson
@@ -910,6 +910,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -964,6 +965,11 @@
     },
     "wof:country":"ZW",
     "wof:country_alpha3":"ZWE",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"69206d7e141365e4238d9d815c61fcaf",
     "wof:hierarchy":[
         {
@@ -982,7 +988,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1566666455,
+    "wof:lastmodified":1582352006,
     "wof:name":"Zimbabwe",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/810/93/85681093.geojson
+++ b/data/856/810/93/85681093.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Mashonaland Central Province"
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0f26d3562b72328ab20f8e43748f7dea",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1566666454,
+    "wof:lastmodified":1582352006,
     "wof:name":"Mashonaland Central",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/810/97/85681097.geojson
+++ b/data/856/810/97/85681097.geojson
@@ -176,6 +176,9 @@
         421201479
     ],
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81999419659c6702b82df68718d89bbc",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1566666454,
+    "wof:lastmodified":1582352006,
     "wof:name":"Harare",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/01/85681101.geojson
+++ b/data/856/811/01/85681101.geojson
@@ -310,6 +310,9 @@
         "wk:page":"Matabeleland North Province"
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d67e4e3c66e4923d8c0cffdce8a44eaa",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1566666453,
+    "wof:lastmodified":1582352005,
     "wof:name":"Matabeleland North",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/03/85681103.geojson
+++ b/data/856/811/03/85681103.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Midlands Province"
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"06f6e77593c2517c434f5e96146b70f3",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1566666451,
+    "wof:lastmodified":1582352004,
     "wof:name":"Midlands",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/09/85681109.geojson
+++ b/data/856/811/09/85681109.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Mashonaland East Province"
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f7a1ffc9d5a4f0f1e392debf76a0cc6",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1566666452,
+    "wof:lastmodified":1582352005,
     "wof:name":"Mashonaland East",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/13/85681113.geojson
+++ b/data/856/811/13/85681113.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Manicaland Province"
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e84b28a70966f946afb189a8f8154aba",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1566666454,
+    "wof:lastmodified":1582352005,
     "wof:name":"Manicaland",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/17/85681117.geojson
+++ b/data/856/811/17/85681117.geojson
@@ -310,6 +310,9 @@
         "wk:page":"Matabeleland South Province"
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"92cd8964b0edc2db4b16047c876f120d",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1566666452,
+    "wof:lastmodified":1582352005,
     "wof:name":"Matabeleland South",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/21/85681121.geojson
+++ b/data/856/811/21/85681121.geojson
@@ -157,6 +157,9 @@
         "wd:id":"Q24045859"
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"691010dbfe26ddf548b9e57055d41cd6",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1566666452,
+    "wof:lastmodified":1582352005,
     "wof:name":"Bulawayo",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/27/85681127.geojson
+++ b/data/856/811/27/85681127.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Masvingo Province"
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a855c2c428e62825cf3d6eceba40aef",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1566666452,
+    "wof:lastmodified":1582352004,
     "wof:name":"Masvingo",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/31/85681131.geojson
+++ b/data/856/811/31/85681131.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Mashonaland West Province"
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e132695ca85c992919afb1b3d0def8d4",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1566666453,
+    "wof:lastmodified":1582352005,
     "wof:name":"Mashonaland West",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/857/719/01/85771901.geojson
+++ b/data/857/719/01/85771901.geojson
@@ -229,6 +229,10 @@
         "qs_pg:id":1096501
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b3daf4b09b6fff5521c1a39f48644227",
     "wof:hierarchy":[
         {
@@ -244,7 +248,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566666451,
+    "wof:lastmodified":1582352004,
     "wof:name":"Arcadia",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/03/85771903.geojson
+++ b/data/857/719/03/85771903.geojson
@@ -172,6 +172,10 @@
         "qs_pg:id":901837
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7038e6cd683d7f75be2c6bff936e0e06",
     "wof:hierarchy":[
         {
@@ -187,7 +191,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566666451,
+    "wof:lastmodified":1582352004,
     "wof:name":"Belmont",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/05/85771905.geojson
+++ b/data/857/719/05/85771905.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":266874
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"646c4e5bfec23a9919941be39fd5da33",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566666451,
+    "wof:lastmodified":1582352004,
     "wof:name":"Eastlea North",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/09/85771909.geojson
+++ b/data/857/719/09/85771909.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":266875
     },
     "wof:country":"ZW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"79b14bc76a29970daa51e8a188e7aa07",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566666451,
+    "wof:lastmodified":1582352004,
     "wof:name":"Kumalo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/416/459/890416459.geojson
+++ b/data/890/416/459/890416459.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051136,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3573b440836fb2c47c9990146ace47a4",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":890416459,
-    "wof:lastmodified":1566666598,
+    "wof:lastmodified":1582352012,
     "wof:name":"Murehwa",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/890/416/461/890416461.geojson
+++ b/data/890/416/461/890416461.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051136,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8930a5ced526bfeb015a96d460a07ff",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890416461,
-    "wof:lastmodified":1566666598,
+    "wof:lastmodified":1582352012,
     "wof:name":"Mudzi",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/890/416/463/890416463.geojson
+++ b/data/890/416/463/890416463.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051136,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30bede20120c50f80426cae18945a376",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890416463,
-    "wof:lastmodified":1566666595,
+    "wof:lastmodified":1582352011,
     "wof:name":"Mberengwa",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/890/416/465/890416465.geojson
+++ b/data/890/416/465/890416465.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051136,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1893bdb0ed34a363fa0bb2550442fa9",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890416465,
-    "wof:lastmodified":1566666595,
+    "wof:lastmodified":1582352011,
     "wof:name":"Mazowe",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/416/469/890416469.geojson
+++ b/data/890/416/469/890416469.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f825e3d929349fa172a82379b067a7cf",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890416469,
-    "wof:lastmodified":1566666598,
+    "wof:lastmodified":1582352011,
     "wof:name":"Hwange",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/890/416/471/890416471.geojson
+++ b/data/890/416/471/890416471.geojson
@@ -81,6 +81,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec88ec18d9da3bba2a2fbe9b2032bf3c",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890416471,
-    "wof:lastmodified":1566666594,
+    "wof:lastmodified":1582352010,
     "wof:name":"Hurungwe",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/890/416/473/890416473.geojson
+++ b/data/890/416/473/890416473.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"524683236440ea2729f11204fd7d816b",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890416473,
-    "wof:lastmodified":1566666597,
+    "wof:lastmodified":1582352011,
     "wof:name":"Gweru",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/890/416/475/890416475.geojson
+++ b/data/890/416/475/890416475.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ebdc38cd1312604a0687a916cf4809bb",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890416475,
-    "wof:lastmodified":1566666596,
+    "wof:lastmodified":1582352011,
     "wof:name":"Gwanda",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/890/416/477/890416477.geojson
+++ b/data/890/416/477/890416477.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb68118930fea19ec361b77d20a7b3d6",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890416477,
-    "wof:lastmodified":1566666594,
+    "wof:lastmodified":1582352010,
     "wof:name":"Gutu",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/890/416/479/890416479.geojson
+++ b/data/890/416/479/890416479.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c485b30704914875b8cabff171a7d8d5",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890416479,
-    "wof:lastmodified":1566666595,
+    "wof:lastmodified":1582352011,
     "wof:name":"Guruve",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/416/481/890416481.geojson
+++ b/data/890/416/481/890416481.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"596de4b10c746e4f803e63e4391701a6",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890416481,
-    "wof:lastmodified":1566666596,
+    "wof:lastmodified":1582352011,
     "wof:name":"Chimanimani",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/416/483/890416483.geojson
+++ b/data/890/416/483/890416483.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98cd95fe7394fb9c588ef7d01dfe5703",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890416483,
-    "wof:lastmodified":1566666594,
+    "wof:lastmodified":1582352011,
     "wof:name":"Chegutu",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/890/416/487/890416487.geojson
+++ b/data/890/416/487/890416487.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a5639590a517a040966cb36c2218335",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890416487,
-    "wof:lastmodified":1566666597,
+    "wof:lastmodified":1582352011,
     "wof:name":"Centenary",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/416/489/890416489.geojson
+++ b/data/890/416/489/890416489.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ddee903ba2fe820c060cdace2d2f4d9",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890416489,
-    "wof:lastmodified":1566666597,
+    "wof:lastmodified":1582352011,
     "wof:name":"Bulilima",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/890/416/491/890416491.geojson
+++ b/data/890/416/491/890416491.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c89eb57ef3c7e963328abcc6be0e8da",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890416491,
-    "wof:lastmodified":1566666596,
+    "wof:lastmodified":1582352011,
     "wof:name":"Buhera",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/416/493/890416493.geojson
+++ b/data/890/416/493/890416493.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051138,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13de0b71b8e34e80e3b71133d31e40f7",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890416493,
-    "wof:lastmodified":1566666597,
+    "wof:lastmodified":1582352011,
     "wof:name":"Bubi",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/890/416/495/890416495.geojson
+++ b/data/890/416/495/890416495.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051138,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a93d5595fa42d569a8eae0109a8ac034",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":890416495,
-    "wof:lastmodified":1566666598,
+    "wof:lastmodified":1582352012,
     "wof:name":"Binga",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/890/416/497/890416497.geojson
+++ b/data/890/416/497/890416497.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051138,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97d0ff19ce64f06f1ae9019d33ffc4b8",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":890416497,
-    "wof:lastmodified":1566666595,
+    "wof:lastmodified":1582352011,
     "wof:name":"Bindura",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/416/499/890416499.geojson
+++ b/data/890/416/499/890416499.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051138,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"44356b1db0572538bba074d87384a27b",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890416499,
-    "wof:lastmodified":1566666595,
+    "wof:lastmodified":1582352011,
     "wof:name":"Bikita",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/890/416/501/890416501.geojson
+++ b/data/890/416/501/890416501.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051138,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fcbeda8a272f099539af5d9dea2de088",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":890416501,
-    "wof:lastmodified":1566666596,
+    "wof:lastmodified":1582352011,
     "wof:name":"Beitbridge",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/890/422/333/890422333.geojson
+++ b/data/890/422/333/890422333.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051438,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d0febcc02260af324c3b4262ded2f5f",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890422333,
-    "wof:lastmodified":1566666589,
+    "wof:lastmodified":1582352009,
     "wof:name":"Makoni",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/422/337/890422337.geojson
+++ b/data/890/422/337/890422337.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051438,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64c8d3414e9ec29b39bd1890d69a8f50",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890422337,
-    "wof:lastmodified":1566666588,
+    "wof:lastmodified":1582352009,
     "wof:name":"Makonde",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/890/428/875/890428875.geojson
+++ b/data/890/428/875/890428875.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051777,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fde18dc7bd1a141da8dd811c91817569",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":890428875,
-    "wof:lastmodified":1566666593,
+    "wof:lastmodified":1582352010,
     "wof:name":"Zvishavane",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/890/428/877/890428877.geojson
+++ b/data/890/428/877/890428877.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051777,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8e920c7af5e5614c57a71a3006011451",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890428877,
-    "wof:lastmodified":1566666593,
+    "wof:lastmodified":1582352010,
     "wof:name":"Goromonzi",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/890/428/879/890428879.geojson
+++ b/data/890/428/879/890428879.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051777,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b97ea3c9c5eb6f151349b7971a51441",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890428879,
-    "wof:lastmodified":1566666593,
+    "wof:lastmodified":1582352010,
     "wof:name":"Chivi",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/890/428/881/890428881.geojson
+++ b/data/890/428/881/890428881.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051777,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f3500ac84dd621d14bcd408dbaf774a1",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890428881,
-    "wof:lastmodified":1566666593,
+    "wof:lastmodified":1582352010,
     "wof:name":"Chiredzi",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/890/430/547/890430547.geojson
+++ b/data/890/430/547/890430547.geojson
@@ -81,6 +81,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469051857,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97fa8e35c4da1bd0558f998f8995a001",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890430547,
-    "wof:lastmodified":1566666589,
+    "wof:lastmodified":1582352009,
     "wof:name":"Chipinge",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/436/413/890436413.geojson
+++ b/data/890/436/413/890436413.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052111,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"374cd831e5aff413284025233fc51d69",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":890436413,
-    "wof:lastmodified":1566666591,
+    "wof:lastmodified":1582352010,
     "wof:name":"Mutasa",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/436/415/890436415.geojson
+++ b/data/890/436/415/890436415.geojson
@@ -71,6 +71,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052111,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72671a5df6a1f7aab07eb2926f53118f",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":890436415,
-    "wof:lastmodified":1566666591,
+    "wof:lastmodified":1582352010,
     "wof:name":"Mutare",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/436/773/890436773.geojson
+++ b/data/890/436/773/890436773.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052125,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59342afb08cc9661b761508f7685901e",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":890436773,
-    "wof:lastmodified":1566666592,
+    "wof:lastmodified":1582352010,
     "wof:name":"Mwenezi",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/890/443/477/890443477.geojson
+++ b/data/890/443/477/890443477.geojson
@@ -211,6 +211,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052425,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4cf5c4733e8bf01c13fd6b0a7e6e0432",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":890443477,
-    "wof:lastmodified":1566666594,
+    "wof:lastmodified":1582352010,
     "wof:name":"Victoria Falls",
     "wof:parent_id":1108784931,
     "wof:placetype":"locality",

--- a/data/890/445/295/890445295.geojson
+++ b/data/890/445/295/890445295.geojson
@@ -71,6 +71,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052504,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9a596299d54162bc521f9cdd2e6fc21f",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":890445295,
-    "wof:lastmodified":1566666598,
+    "wof:lastmodified":1582352012,
     "wof:name":"Marondera",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/890/450/097/890450097.geojson
+++ b/data/890/450/097/890450097.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052725,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7db428782427c9a2cfed81087330743",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890450097,
-    "wof:lastmodified":1566666600,
+    "wof:lastmodified":1582352012,
     "wof:name":"Umzingwane",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/890/450/099/890450099.geojson
+++ b/data/890/450/099/890450099.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052725,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a129419321dc271f4f4e4201c43f239",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":890450099,
-    "wof:lastmodified":1566666599,
+    "wof:lastmodified":1582352012,
     "wof:name":"Shurugwi",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/890/450/101/890450101.geojson
+++ b/data/890/450/101/890450101.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052726,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7cb614e312b6653b716398abc3e0feb",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890450101,
-    "wof:lastmodified":1566666600,
+    "wof:lastmodified":1582352012,
     "wof:name":"Shamva",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/450/103/890450103.geojson
+++ b/data/890/450/103/890450103.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052726,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fc13624432b3dd3fe3e4a80a6951ec68",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":890450103,
-    "wof:lastmodified":1566666599,
+    "wof:lastmodified":1582352012,
     "wof:name":"Rushinga",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/450/105/890450105.geojson
+++ b/data/890/450/105/890450105.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052726,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ff7f4ccade8593915932dcc940baafd",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890450105,
-    "wof:lastmodified":1566666599,
+    "wof:lastmodified":1582352012,
     "wof:name":"Nyanga",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/450/107/890450107.geojson
+++ b/data/890/450/107/890450107.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052726,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"161a2ec09055baf9bd93f7c686380da5",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890450107,
-    "wof:lastmodified":1566666600,
+    "wof:lastmodified":1582352012,
     "wof:name":"Nkayi",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/890/452/761/890452761.geojson
+++ b/data/890/452/761/890452761.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052828,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"42163b97acfb4a14cc3013a3896569d3",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":890452761,
-    "wof:lastmodified":1566666590,
+    "wof:lastmodified":1582352010,
     "wof:name":"Matobo",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/890/452/765/890452765.geojson
+++ b/data/890/452/765/890452765.geojson
@@ -105,6 +105,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052828,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"06d560cddc462723c982c22673b4809e",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":890452765,
-    "wof:lastmodified":1566666590,
+    "wof:lastmodified":1582352009,
     "wof:name":"Lupane",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/890/452/767/890452767.geojson
+++ b/data/890/452/767/890452767.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052829,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dbe6a4b259fed471bd303928f6e8f13e",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":890452767,
-    "wof:lastmodified":1566666590,
+    "wof:lastmodified":1582352009,
     "wof:name":"Kwekwe",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/890/452/769/890452769.geojson
+++ b/data/890/452/769/890452769.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052829,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"36af3e978947c17084fd3a4009e02eef",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890452769,
-    "wof:lastmodified":1566666590,
+    "wof:lastmodified":1582352009,
     "wof:name":"Kariba",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/890/452/771/890452771.geojson
+++ b/data/890/452/771/890452771.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052829,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a263aa31cacf18f605c062a5d90bbf6e",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890452771,
-    "wof:lastmodified":1566666590,
+    "wof:lastmodified":1582352009,
     "wof:name":"Kadoma Urban",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/890/452/775/890452775.geojson
+++ b/data/890/452/775/890452775.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"ZW",
     "wof:created":1469052829,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7438c391bab1eebdb025f9daebb52fe5",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":890452775,
-    "wof:lastmodified":1566666591,
+    "wof:lastmodified":1582352010,
     "wof:name":"Insiza",
     "wof:parent_id":85681117,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.