### PR TITLE
zw concordances, placetype local, and more

### DIFF
--- a/data/110/878/486/3/1108784863.geojson
+++ b/data/110/878/486/3/1108784863.geojson
@@ -155,6 +155,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.HA.CT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830374,
     "wof:geomhash":"d4eef1d82c832f5bdd3b342cd96467b8",
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":1108784863,
-    "wof:lastmodified":1694492940,
+    "wof:lastmodified":1695886051,
     "wof:name":"Chitungwiza",
     "wof:parent_id":85681097,
     "wof:placetype":"county",

--- a/data/110/878/486/5/1108784865.geojson
+++ b/data/110/878/486/5/1108784865.geojson
@@ -80,6 +80,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.HA.EP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830376,
     "wof:geomhash":"0a9a8f28dbfec9d26bb0f642f9b74c43",
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108784865,
-    "wof:lastmodified":1694492411,
+    "wof:lastmodified":1695886577,
     "wof:name":"Epworth",
     "wof:parent_id":85681097,
     "wof:placetype":"county",

--- a/data/110/878/486/7/1108784867.geojson
+++ b/data/110/878/486/7/1108784867.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MA.CP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830378,
     "wof:geomhash":"f7a6e084b3341411b389386f8580e118",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784867,
-    "wof:lastmodified":1694492838,
+    "wof:lastmodified":1695886277,
     "wof:name":"Chipinge Urban",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/110/878/486/9/1108784869.geojson
+++ b/data/110/878/486/9/1108784869.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MA.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830379,
     "wof:geomhash":"3b26a80efd85f79f05c288315a0689f0",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784869,
-    "wof:lastmodified":1694492868,
+    "wof:lastmodified":1695886353,
     "wof:name":"Mutare Urban",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/110/878/487/3/1108784873.geojson
+++ b/data/110/878/487/3/1108784873.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MC.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830380,
     "wof:geomhash":"81b4873f2c527a9c3aa9046e1d001c85",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784873,
-    "wof:lastmodified":1694492833,
+    "wof:lastmodified":1695886267,
     "wof:name":"Bindura Urban",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/110/878/487/5/1108784875.geojson
+++ b/data/110/878/487/5/1108784875.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MC.GV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830381,
     "wof:geomhash":"333870b34c316db60c4828070047c3e6",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784875,
-    "wof:lastmodified":1694492866,
+    "wof:lastmodified":1695886348,
     "wof:name":"Mbire",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/110/878/487/7/1108784877.geojson
+++ b/data/110/878/487/7/1108784877.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MC.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830383,
     "wof:geomhash":"6aa8204250821d93021dd9fc2453d32e",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108784877,
-    "wof:lastmodified":1694492824,
+    "wof:lastmodified":1695886245,
     "wof:name":"Mount Darwin",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/110/878/487/9/1108784879.geojson
+++ b/data/110/878/487/9/1108784879.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.ME.CK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830384,
     "wof:geomhash":"33276cec56a1cbfd316949bf38dd6a36",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784879,
-    "wof:lastmodified":1694492838,
+    "wof:lastmodified":1695886277,
     "wof:name":"Chikomba",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/110/878/488/1/1108784881.geojson
+++ b/data/110/878/488/1/1108784881.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.ME.WE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830385,
     "wof:geomhash":"53daa617c5ed4b6d3d70fbcfcab1baac",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784881,
-    "wof:lastmodified":1694492849,
+    "wof:lastmodified":1695886303,
     "wof:name":"Hwedza",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/110/878/488/3/1108784883.geojson
+++ b/data/110/878/488/3/1108784883.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.ME.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830386,
     "wof:geomhash":"7f9428169d4697e477807d4903418983",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784883,
-    "wof:lastmodified":1694492865,
+    "wof:lastmodified":1695886347,
     "wof:name":"Marondera Urban",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/110/878/488/5/1108784885.geojson
+++ b/data/110/878/488/5/1108784885.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.ME.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830393,
     "wof:geomhash":"6e7a6ec428f3bc877a5426f71dd4312c",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108784885,
-    "wof:lastmodified":1694492824,
+    "wof:lastmodified":1695886245,
     "wof:name":"Mutoko",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/110/878/488/7/1108784887.geojson
+++ b/data/110/878/488/7/1108784887.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MA.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830394,
     "wof:geomhash":"05a60cebcdaa6a51dc3f099c14e01f36",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784887,
-    "wof:lastmodified":1694492881,
+    "wof:lastmodified":1695886393,
     "wof:name":"Rusape Urban",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/110/878/489/1/1108784891.geojson
+++ b/data/110/878/489/1/1108784891.geojson
@@ -89,6 +89,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.ME.GM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830395,
     "wof:geomhash":"e0c9af6db51968a521374f6c7314b1b0",
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108784891,
-    "wof:lastmodified":1694492411,
+    "wof:lastmodified":1695886577,
     "wof:name":"Ruwa",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/110/878/489/3/1108784893.geojson
+++ b/data/110/878/489/3/1108784893.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.ME.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830396,
     "wof:geomhash":"ebcb2b6626042d9c2b2dfe6767f91ad2",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784893,
-    "wof:lastmodified":1694492883,
+    "wof:lastmodified":1695886397,
     "wof:name":"Seke",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/110/878/489/5/1108784895.geojson
+++ b/data/110/878/489/5/1108784895.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.ME.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830398,
     "wof:geomhash":"3aefc9697b9306256e61816db9bebc73",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784895,
-    "wof:lastmodified":1694492892,
+    "wof:lastmodified":1695886418,
     "wof:name":"Uzumba Maramba Pfungwe",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/110/878/489/7/1108784897.geojson
+++ b/data/110/878/489/7/1108784897.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MW.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830399,
     "wof:geomhash":"a32139c5393d1573ae130d163b9c1110",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784897,
-    "wof:lastmodified":1694492837,
+    "wof:lastmodified":1695886276,
     "wof:name":"Chegutu Urban",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/110/878/489/9/1108784899.geojson
+++ b/data/110/878/489/9/1108784899.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MW.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830400,
     "wof:geomhash":"c6eb6a63c93a277e207a05aea14b7e0b",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784899,
-    "wof:lastmodified":1694492838,
+    "wof:lastmodified":1695886277,
     "wof:name":"Chinhoyi Urban",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/110/878/490/1/1108784901.geojson
+++ b/data/110/878/490/1/1108784901.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MW.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830401,
     "wof:geomhash":"eb24744437067584af2a094a0aa41a21",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784901,
-    "wof:lastmodified":1694492853,
+    "wof:lastmodified":1695886313,
     "wof:name":"Kariba Urban",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/110/878/490/3/1108784903.geojson
+++ b/data/110/878/490/3/1108784903.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MW.HU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830403,
     "wof:geomhash":"03dae4cca4bd0abf147b218a21f76825",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784903,
-    "wof:lastmodified":1694492853,
+    "wof:lastmodified":1695886313,
     "wof:name":"Karoi Urban",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/110/878/490/5/1108784905.geojson
+++ b/data/110/878/490/5/1108784905.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MW.KD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830404,
     "wof:geomhash":"15a1cbe3ecf73389a6619b2a90b2c280",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784905,
-    "wof:lastmodified":1694492866,
+    "wof:lastmodified":1695886348,
     "wof:name":"Mhondoro-Ngezi",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/110/878/490/9/1108784909.geojson
+++ b/data/110/878/490/9/1108784909.geojson
@@ -125,6 +125,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MW.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830405,
     "wof:geomhash":"6d2f535f8675c4490e9a272cf0a17be6",
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108784909,
-    "wof:lastmodified":1694492410,
+    "wof:lastmodified":1695886577,
     "wof:name":"Norton",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/110/878/491/1/1108784911.geojson
+++ b/data/110/878/491/1/1108784911.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MW.KD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830406,
     "wof:geomhash":"c422c2f5fcf0fefea35081169b2b5439",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108784911,
-    "wof:lastmodified":1694492824,
+    "wof:lastmodified":1695886246,
     "wof:name":"Sanyati",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/110/878/491/3/1108784913.geojson
+++ b/data/110/878/491/3/1108784913.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MW.ZB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830407,
     "wof:geomhash":"42e7fa7af6cbcd1a5d2d6206e244174d",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784913,
-    "wof:lastmodified":1694492899,
+    "wof:lastmodified":1695886435,
     "wof:name":"Zvimba",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/110/878/491/5/1108784915.geojson
+++ b/data/110/878/491/5/1108784915.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MV.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830408,
     "wof:geomhash":"ffae957b0e4bdda076c2ef69357c6658",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784915,
-    "wof:lastmodified":1694492838,
+    "wof:lastmodified":1695886277,
     "wof:name":"Chiredzi Urban",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/110/878/491/7/1108784917.geojson
+++ b/data/110/878/491/7/1108784917.geojson
@@ -140,6 +140,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MV.MV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830409,
     "wof:geomhash":"a6a33abf004ef11f193b3501087716c1",
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108784917,
-    "wof:lastmodified":1694492940,
+    "wof:lastmodified":1695886051,
     "wof:name":"Masvingo",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/110/878/491/9/1108784919.geojson
+++ b/data/110/878/491/9/1108784919.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MV.MV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830410,
     "wof:geomhash":"49342b58df9689ad1a10efaf39031779",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784919,
-    "wof:lastmodified":1694492865,
+    "wof:lastmodified":1695886347,
     "wof:name":"Masvingo Urban",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/110/878/492/1/1108784921.geojson
+++ b/data/110/878/492/1/1108784921.geojson
@@ -62,6 +62,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MV.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830412,
     "wof:geomhash":"fa51a907fe9a1307199db0153907c9b0",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108784921,
-    "wof:lastmodified":1694492411,
+    "wof:lastmodified":1695886577,
     "wof:name":"Zaka",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/110/878/492/3/1108784923.geojson
+++ b/data/110/878/492/3/1108784923.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MN.HW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830413,
     "wof:geomhash":"d0e91263b790fda257232e9812fe0025",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784923,
-    "wof:lastmodified":1694492849,
+    "wof:lastmodified":1695886303,
     "wof:name":"Hwange Urban",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/110/878/492/7/1108784927.geojson
+++ b/data/110/878/492/7/1108784927.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MN.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830414,
     "wof:geomhash":"abf12bfc2c6d1d8feda17871a676c1ad",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784927,
-    "wof:lastmodified":1694492891,
+    "wof:lastmodified":1695886416,
     "wof:name":"Tsholotsho",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/110/878/492/9/1108784929.geojson
+++ b/data/110/878/492/9/1108784929.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MN.UG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830415,
     "wof:geomhash":"8ec4501f05c23a51ac392f000b578d66",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784929,
-    "wof:lastmodified":1694492891,
+    "wof:lastmodified":1695886417,
     "wof:name":"Umguza",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/110/878/493/1/1108784931.geojson
+++ b/data/110/878/493/1/1108784931.geojson
@@ -284,6 +284,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MN.HW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830416,
     "wof:geomhash":"22ba9c3e7c6bfa5b727bc29d8756a3ce",
@@ -296,7 +297,7 @@
         }
     ],
     "wof:id":1108784931,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886052,
     "wof:name":"Victoria Falls",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/110/878/493/3/1108784933.geojson
+++ b/data/110/878/493/3/1108784933.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MS.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830418,
     "wof:geomhash":"628d15608653acc307595e8eb6cae6a5",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784933,
-    "wof:lastmodified":1694492830,
+    "wof:lastmodified":1695886258,
     "wof:name":"Beitbridge Urban",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/110/878/493/5/1108784935.geojson
+++ b/data/110/878/493/5/1108784935.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MS.GD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830419,
     "wof:geomhash":"fb6f4f8b6b138f81c04f76b5f3567d00",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784935,
-    "wof:lastmodified":1694492848,
+    "wof:lastmodified":1695886301,
     "wof:name":"Gwanda Urban",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/110/878/493/7/1108784937.geojson
+++ b/data/110/878/493/7/1108784937.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MS.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830420,
     "wof:geomhash":"e77a8e5c75a24b798ee10a4d765089b3",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784937,
-    "wof:lastmodified":1694492865,
+    "wof:lastmodified":1695886344,
     "wof:name":"Mangwe",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/110/878/493/9/1108784939.geojson
+++ b/data/110/878/493/9/1108784939.geojson
@@ -110,6 +110,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MS.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830421,
     "wof:geomhash":"77bc8d218491a033c89aa109ba8a3042",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108784939,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886052,
     "wof:name":"Plumtree",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/110/878/494/1/1108784941.geojson
+++ b/data/110/878/494/1/1108784941.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MI.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830422,
     "wof:geomhash":"31778da9f0c32a4abbce539ca3806f3f",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784941,
-    "wof:lastmodified":1694492838,
+    "wof:lastmodified":1695886277,
     "wof:name":"Chirumhanzu",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/110/878/494/5/1108784945.geojson
+++ b/data/110/878/494/5/1108784945.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MI.GN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830423,
     "wof:geomhash":"7e675588f2afd1c0fc7cf36f173c8a41",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784945,
-    "wof:lastmodified":1694492847,
+    "wof:lastmodified":1695886297,
     "wof:name":"Gokwe North",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/110/878/494/7/1108784947.geojson
+++ b/data/110/878/494/7/1108784947.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MI.GS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830424,
     "wof:geomhash":"11a5283e1f5d841d9609901e04d209ff",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784947,
-    "wof:lastmodified":1694492847,
+    "wof:lastmodified":1695886297,
     "wof:name":"Gokwe South",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/110/878/494/9/1108784949.geojson
+++ b/data/110/878/494/9/1108784949.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MI.GS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830425,
     "wof:geomhash":"148a3c138552b4fdef4f75de4409ca3e",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784949,
-    "wof:lastmodified":1694492847,
+    "wof:lastmodified":1695886297,
     "wof:name":"Gokwe South Urban",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/110/878/495/1/1108784951.geojson
+++ b/data/110/878/495/1/1108784951.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MI.GW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830426,
     "wof:geomhash":"40afe48278dfab27f215e44015eb3c11",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784951,
-    "wof:lastmodified":1694492848,
+    "wof:lastmodified":1695886301,
     "wof:name":"Gweru Urban",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/110/878/495/3/1108784953.geojson
+++ b/data/110/878/495/3/1108784953.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MI.KW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830428,
     "wof:geomhash":"55587cba8bf17a648f34cf957cee8e86",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784953,
-    "wof:lastmodified":1694492858,
+    "wof:lastmodified":1695886327,
     "wof:name":"Kwekwe Urban",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/110/878/495/5/1108784955.geojson
+++ b/data/110/878/495/5/1108784955.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MI.KW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830429,
     "wof:geomhash":"46e783cf0b12e9e47111fbc9b9be42ab",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108784955,
-    "wof:lastmodified":1694492411,
+    "wof:lastmodified":1695886577,
     "wof:name":"Redcliff",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/110/878/495/7/1108784957.geojson
+++ b/data/110/878/495/7/1108784957.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MI.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830430,
     "wof:geomhash":"9cfaf8da6d914b4f0ac9c46e70c40376",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784957,
-    "wof:lastmodified":1694492884,
+    "wof:lastmodified":1695886399,
     "wof:name":"Shurugwi Urban",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/110/878/495/9/1108784959.geojson
+++ b/data/110/878/495/9/1108784959.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ZW.MI.ZV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1481830431,
     "wof:geomhash":"74375adb5f0ca6978e7e1b4af68b639d",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784959,
-    "wof:lastmodified":1694492899,
+    "wof:lastmodified":1695886436,
     "wof:name":"Zvishavane Urban",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/421/171/051/421171051.geojson
+++ b/data/421/171/051/421171051.geojson
@@ -249,6 +249,7 @@
         "hasc:id":"ZW.BU.BL",
         "qs_pg:id":1206079
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85681121
     ],
@@ -267,7 +268,7 @@
         }
     ],
     "wof:id":421171051,
-    "wof:lastmodified":1694492547,
+    "wof:lastmodified":1695886408,
     "wof:name":"Bulawayo",
     "wof:parent_id":85681121,
     "wof:placetype":"county",

--- a/data/421/190/261/421190261.geojson
+++ b/data/421/190/261/421190261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072915,
-    "geom:area_square_m":858250910.239838,
+    "geom:area_square_m":858250910.239882,
     "geom:bbox":"30.878537,-18.003372,31.220937,-17.665572",
     "geom:latitude":-17.839848,
     "geom:longitude":31.048996,
@@ -530,6 +530,7 @@
         "wd:id":"Q3921",
         "wk:page":"Harare"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85681097
     ],
@@ -538,7 +539,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"106b947fac37ef68fa2e702e09981962",
+    "wof:geomhash":"b0db72ff335ed7f88fdfb95322672c42",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -548,7 +549,7 @@
         }
     ],
     "wof:id":421190261,
-    "wof:lastmodified":1690930144,
+    "wof:lastmodified":1695886409,
     "wof:name":"Harare Urban",
     "wof:parent_id":85681097,
     "wof:placetype":"county",

--- a/data/856/322/43/85632243.geojson
+++ b/data/856/322/43/85632243.geojson
@@ -1163,6 +1163,7 @@
         "hasc:id":"ZW",
         "icao:code":"Z",
         "ioc:id":"ZIM",
+        "iso:code":"ZW",
         "itu:id":"ZWE",
         "m49:code":"716",
         "marc:id":"rh",
@@ -1176,6 +1177,7 @@
         "wk:page":"Zimbabwe",
         "wmo:id":"ZW"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZW",
     "wof:country_alpha3":"ZWE",
     "wof:geom_alt":[
@@ -1201,7 +1203,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1694639548,
+    "wof:lastmodified":1695881206,
     "wof:name":"Zimbabwe",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/810/93/85681093.geojson
+++ b/data/856/810/93/85681093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.388389,
-    "geom:area_square_m":28286634823.055202,
+    "geom:area_square_m":28286635248.054592,
     "geom:bbox":"30.047637,-17.740272,32.756437,-15.618572",
     "geom:latitude":-16.698777,
     "geom:longitude":31.194099,
@@ -314,17 +314,19 @@
         "gn:id":886843,
         "gp:id":2347812,
         "hasc:id":"ZW.MC",
+        "iso:code":"ZW-MC",
         "iso:id":"ZW-MC",
         "qs_pg:id":235672,
         "unlc:id":"ZW-MC",
         "wd:id":"Q596156",
         "wk:page":"Mashonaland Central Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"64038ec9ab8024ef0117ecdbe0fb7c1e",
+    "wof:geomhash":"b378becbf293873c84b89ccdcca33514",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -343,7 +345,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1690930136,
+    "wof:lastmodified":1695884924,
     "wof:name":"Mashonaland Central",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/810/97/85681097.geojson
+++ b/data/856/810/97/85681097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080073,
-    "geom:area_square_m":942449630.161678,
+    "geom:area_square_m":942449630.161684,
     "geom:bbox":"30.878537,-18.050072,31.220937,-17.665572",
     "geom:latitude":-17.850979,
     "geom:longitude":31.053814,
@@ -235,12 +235,14 @@
         "gn:id":1105844,
         "gp:id":24550731,
         "hasc:id":"ZW.HA",
+        "iso:code":"ZW-HA",
         "iso:id":"ZW-HA",
         "qs_pg:id":1127713,
         "unlc:id":"ZW-HA",
         "wd:id":"Q16928358",
         "wk:page":"Harare Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421201479,
         421190261
@@ -249,7 +251,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8f7a497e6eceaa472aaf456e83a6fe64",
+    "wof:geomhash":"69c095f94841caba33ea729b4f34ae7c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -268,7 +270,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1690930136,
+    "wof:lastmodified":1695884925,
     "wof:name":"Harare",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/01/85681101.geojson
+++ b/data/856/811/01/85681101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.467497,
-    "geom:area_square_m":75688904517.993195,
+    "geom:area_square_m":75688904291.419418,
     "geom:bbox":"25.237737,-20.361872,29.232937,-16.878299",
     "geom:latitude":-18.823369,
     "geom:longitude":27.40082,
@@ -327,17 +327,19 @@
         "gn:id":886748,
         "gp:id":2347815,
         "hasc:id":"ZW.MN",
+        "iso:code":"ZW-MN",
         "iso:id":"ZW-MN",
         "qs_pg:id":1285734,
         "unlc:id":"ZW-MN",
         "wd:id":"Q456562",
         "wk:page":"Matabeleland North Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e3268a79039512d57712d21088992267",
+    "wof:geomhash":"b5d39d56ac04fea3a182d1bd19e3d74d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -356,7 +358,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1690930135,
+    "wof:lastmodified":1695884925,
     "wof:name":"Matabeleland North",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/03/85681103.geojson
+++ b/data/856/811/03/85681103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.235504,
-    "geom:area_square_m":49517775475.856606,
+    "geom:area_square_m":49517775350.816772,
     "geom:bbox":"27.998237,-21.043372,30.870437,-17.118164",
     "geom:latitude":-18.981404,
     "geom:longitude":29.464057,
@@ -310,17 +310,19 @@
         "gn:id":886119,
         "gp:id":2347811,
         "hasc:id":"ZW.MI",
+        "iso:code":"ZW-MI",
         "iso:id":"ZW-MI",
         "qs_pg:id":895033,
         "unlc:id":"ZW-MI",
         "wd:id":"Q456556",
         "wk:page":"Midlands Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e29c8faaf4cc3e33100db0edacd4d3fe",
+    "wof:geomhash":"7d6a5074eb88c56c45e8f96b8d0e9789",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -339,7 +341,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1690930133,
+    "wof:lastmodified":1695884924,
     "wof:name":"Midlands",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/09/85681109.geojson
+++ b/data/856/811/09/85681109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.745819,
-    "geom:area_square_m":32292023930.709209,
+    "geom:area_square_m":32292023520.184875,
     "geom:bbox":"30.554637,-19.260372,32.994237,-16.693672",
     "geom:latitude":-17.980473,
     "geom:longitude":31.696507,
@@ -323,17 +323,19 @@
         "gn:id":886842,
         "gp:id":2347813,
         "hasc:id":"ZW.ME",
+        "iso:code":"ZW-ME",
         "iso:id":"ZW-ME",
         "qs_pg:id":479632,
         "unlc:id":"ZW-ME",
         "wd:id":"Q465853",
         "wk:page":"Mashonaland East Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b659b7bfec67710048c5642ab959600",
+    "wof:geomhash":"28ab7ddd09fb9fc27188d5170552a33b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -352,7 +354,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1690930134,
+    "wof:lastmodified":1695884924,
     "wof:name":"Mashonaland East",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/13/85681113.geojson
+++ b/data/856/811/13/85681113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.076728,
-    "geom:area_square_m":35953860074.411835,
+    "geom:area_square_m":35953861422.587395,
     "geom:bbox":"31.188571,-21.327272,33.066837,-17.245672",
     "geom:latitude":-19.06229,
     "geom:longitude":32.398106,
@@ -307,17 +307,19 @@
         "gn:id":887358,
         "gp:id":2347810,
         "hasc:id":"ZW.MA",
+        "iso:code":"ZW-MA",
         "iso:id":"ZW-MA",
         "qs_pg:id":1168790,
         "unlc:id":"ZW-MA",
         "wd:id":"Q465847",
         "wk:page":"Manicaland Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"81fdf039e93ddf41742268f575ddb374",
+    "wof:geomhash":"0041b2fd3d4dd638c307c9f79bda89d5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -336,7 +338,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1690930135,
+    "wof:lastmodified":1695884925,
     "wof:name":"Manicaland",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/17/85681117.geojson
+++ b/data/856/811/17/85681117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.702246,
-    "geom:area_square_m":54274475727.833626,
+    "geom:area_square_m":54274474698.358139,
     "geom:bbox":"26.702337,-22.354872,31.113337,-19.481872",
     "geom:latitude":-21.010544,
     "geom:longitude":28.992054,
@@ -330,17 +330,19 @@
         "gn:id":886747,
         "gp:id":2347816,
         "hasc:id":"ZW.MS",
+        "iso:code":"ZW-MS",
         "iso:id":"ZW-MS",
         "qs_pg:id":1285735,
         "unlc:id":"ZW-MS",
         "wd:id":"Q498355",
         "wk:page":"Matabeleland South Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"97d1b82c931af67e3e03f6a35cd666f5",
+    "wof:geomhash":"ddfb723904b52552e8849b255d59527d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -359,7 +361,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1690930134,
+    "wof:lastmodified":1695884924,
     "wof:name":"Matabeleland South",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/21/85681121.geojson
+++ b/data/856/811/21/85681121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047173,
-    "geom:area_square_m":547698689.332823,
+    "geom:area_square_m":547698689.332808,
     "geom:bbox":"28.387437,-20.258672,28.696737,-19.961472",
     "geom:latitude":-20.121821,
     "geom:longitude":28.555622,
@@ -154,11 +154,13 @@
         "gn:id":1105843,
         "gp:id":24550730,
         "hasc:id":"ZW.BU",
+        "iso:code":"ZW-BU",
         "iso:id":"ZW-BU",
         "qs_pg:id":1086157,
         "unlc:id":"ZW-BU",
         "wd:id":"Q24045859"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421171051
     ],
@@ -166,7 +168,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"67a341e3afaed2d01f503cb4a44adf3c",
+    "wof:geomhash":"882404a5f78554041d52643483e33242",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -185,7 +187,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1690930134,
+    "wof:lastmodified":1695884473,
     "wof:name":"Bulawayo",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/27/85681127.geojson
+++ b/data/856/811/27/85681127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.897893,
-    "geom:area_square_m":56616466238.98481,
+    "geom:area_square_m":56616466402.294701,
     "geom:bbox":"29.726637,-22.420972,32.447491,-19.148772",
     "geom:latitude":-20.786435,
     "geom:longitude":31.238632,
@@ -307,17 +307,19 @@
         "gn:id":886761,
         "gp:id":2347817,
         "hasc:id":"ZW.MV",
+        "iso:code":"ZW-MV",
         "iso:id":"ZW-MV",
         "qs_pg:id":895035,
         "unlc:id":"ZW-MV",
         "wd:id":"Q498351",
         "wk:page":"Masvingo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe01a8d75566b6a62a68fbe25f2e0011",
+    "wof:geomhash":"741a7207c70065642d18fa363d42f3b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -336,7 +338,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1690930133,
+    "wof:lastmodified":1695884924,
     "wof:name":"Masvingo",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/856/811/31/85681131.geojson
+++ b/data/856/811/31/85681131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.899224,
-    "geom:area_square_m":57870769415.842346,
+    "geom:area_square_m":57870769511.504845,
     "geom:bbox":"28.013937,-18.911472,30.962537,-15.607172",
     "geom:latitude":-17.181485,
     "geom:longitude":29.707222,
@@ -326,17 +326,19 @@
         "gn:id":886841,
         "gp:id":2347814,
         "hasc:id":"ZW.MW",
+        "iso:code":"ZW-MW",
         "iso:id":"ZW-MW",
         "qs_pg:id":895034,
         "unlc:id":"ZW-MW",
         "wd:id":"Q457189",
         "wk:page":"Mashonaland West Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ZW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b34b21702a548eac019745e647a7b341",
+    "wof:geomhash":"8a230d75b8a2fba1e8318870462783be",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -355,7 +357,7 @@
         "sna",
         "nde"
     ],
-    "wof:lastmodified":1690930135,
+    "wof:lastmodified":1695884924,
     "wof:name":"Mashonaland West",
     "wof:parent_id":85632243,
     "wof:placetype":"region",

--- a/data/890/416/459/890416459.geojson
+++ b/data/890/416/459/890416459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.302931,
-    "geom:area_square_m":3566532692.780061,
+    "geom:area_square_m":3566532941.090199,
     "geom:bbox":"31.516737,-18.229172,32.213463,-17.368872",
     "geom:latitude":-17.796762,
     "geom:longitude":31.821699,
@@ -81,12 +81,13 @@
         "wd:id":"Q17107989",
         "wk:page":"Uzumba-Maramba-Pfungwe"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051136,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1f3c0637e385214263d1509a3ce491df",
+    "wof:geomhash":"9e12ab33b6f7882f7e874768d407ea04",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890416459,
-    "wof:lastmodified":1690930157,
+    "wof:lastmodified":1695886245,
     "wof:name":"Murehwa",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/890/416/461/890416461.geojson
+++ b/data/890/416/461/890416461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.352897,
-    "geom:area_square_m":4172258359.12428,
+    "geom:area_square_m":4172258490.833235,
     "geom:bbox":"32.172737,-17.406572,32.994237,-16.693672",
     "geom:latitude":-17.031259,
     "geom:longitude":32.638062,
@@ -78,12 +78,13 @@
         "wd:id":"Q16895534",
         "wk:page":"Mudzi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051136,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f411e58c60f27deb242ecf995d78f071",
+    "wof:geomhash":"ce65c84e7a6b82ae924d069c1b7e5a60",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":890416461,
-    "wof:lastmodified":1690930157,
+    "wof:lastmodified":1695886245,
     "wof:name":"Mudzi",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/890/416/463/890416463.geojson
+++ b/data/890/416/463/890416463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.439381,
-    "geom:area_square_m":5080817276.314624,
+    "geom:area_square_m":5080817208.279516,
     "geom:bbox":"29.457737,-21.043372,30.519895,-20.333972",
     "geom:latitude":-20.743649,
     "geom:longitude":30.010189,
@@ -90,12 +90,13 @@
         "wd:id":"Q1686393",
         "wk:page":"Mberengwa District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051136,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e49ee971fc91ecbbd776c5f9db41f7fc",
+    "wof:geomhash":"38377a389341cc14ba44c38cd43e22ba",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":890416463,
-    "wof:lastmodified":1690930154,
+    "wof:lastmodified":1695886245,
     "wof:name":"Mberengwa",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/890/416/465/890416465.geojson
+++ b/data/890/416/465/890416465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.370039,
-    "geom:area_square_m":4369709802.185827,
+    "geom:area_square_m":4369709454.914796,
     "geom:bbox":"30.611637,-17.740272,31.284754,-16.784872",
     "geom:latitude":-17.252134,
     "geom:longitude":30.931538,
@@ -120,12 +120,13 @@
         "wd:id":"Q1756321",
         "wk:page":"Mazowe District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051136,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1b31cbd23651b01f364cdd571c0cb8c0",
+    "wof:geomhash":"97584c19177be987ddfba957b68a9ac4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":890416465,
-    "wof:lastmodified":1690930154,
+    "wof:lastmodified":1695886052,
     "wof:name":"Mazowe",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/416/469/890416469.geojson
+++ b/data/890/416/469/890416469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.310424,
-    "geom:area_square_m":27058165854.474178,
+    "geom:area_square_m":27058165229.53476,
     "geom:bbox":"25.237737,-19.888172,27.467337,-17.790072",
     "geom:latitude":-18.70982,
     "geom:longitude":26.423749,
@@ -111,12 +111,13 @@
         "wd:id":"Q5951997",
         "wk:page":"Hwange District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7b4d990541b49c49061a5bb197671ab7",
+    "wof:geomhash":"e6ac376f329f659003f0bcc99f71ba4f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":890416469,
-    "wof:lastmodified":1690930156,
+    "wof:lastmodified":1695886053,
     "wof:name":"Hwange",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/890/416/471/890416471.geojson
+++ b/data/890/416/471/890416471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.678976,
-    "geom:area_square_m":19911890793.812283,
+    "geom:area_square_m":19911890366.676647,
     "geom:bbox":"28.823037,-17.433772,30.334637,-15.607172",
     "geom:latitude":-16.435157,
     "geom:longitude":29.536834,
@@ -96,12 +96,13 @@
         "wd:id":"Q6373010",
         "wk:page":"Karoi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0c0b4b1fc26e3229c1c929c19da1df99",
+    "wof:geomhash":"4760ff71db57e486f46da6ebcab9e3ce",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890416471,
-    "wof:lastmodified":1690930153,
+    "wof:lastmodified":1695886244,
     "wof:name":"Hurungwe",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/890/416/473/890416473.geojson
+++ b/data/890/416/473/890416473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.506662,
-    "geom:area_square_m":5906795189.138357,
+    "geom:area_square_m":5906794925.226105,
     "geom:bbox":"29.092053,-19.973172,30.187137,-19.091572",
     "geom:latitude":-19.466809,
     "geom:longitude":29.63692,
@@ -81,12 +81,13 @@
         "wd:id":"Q23808643",
         "wk:page":"Gweru District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4245ab4a028a06401c38dfebce4dc8b5",
+    "wof:geomhash":"80d5c43a9516bcbca82b7f2119d637d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890416473,
-    "wof:lastmodified":1690930156,
+    "wof:lastmodified":1695886053,
     "wof:name":"Gweru",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/890/416/475/890416475.geojson
+++ b/data/890/416/475/890416475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.931996,
-    "geom:area_square_m":10741610413.925343,
+    "geom:area_square_m":10741610052.306864,
     "geom:bbox":"28.620737,-21.996772,29.905302,-20.557372",
     "geom:latitude":-21.236211,
     "geom:longitude":29.162385,
@@ -117,12 +117,13 @@
         "wd:id":"Q5623288",
         "wk:page":"Gwanda District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"63099ad212d25fe2bb5b4d4166353dfe",
+    "wof:geomhash":"c13578eb3df97b11389ba498769bd031",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":890416475,
-    "wof:lastmodified":1690930155,
+    "wof:lastmodified":1695886053,
     "wof:name":"Gwanda",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/890/416/477/890416477.geojson
+++ b/data/890/416/477/890416477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.607348,
-    "geom:area_square_m":7074341706.359824,
+    "geom:area_square_m":7074341310.810237,
     "geom:bbox":"30.687337,-20.032772,31.971526,-19.148772",
     "geom:latitude":-19.610797,
     "geom:longitude":31.242509,
@@ -108,12 +108,13 @@
         "wd:id":"Q489622",
         "wk:page":"Gutu"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7177c47dd2e2fbe94fcf101a7739ecd7",
+    "wof:geomhash":"a77fdfdb237445136350b73f5db461c9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":890416477,
-    "wof:lastmodified":1690930153,
+    "wof:lastmodified":1695886801,
     "wof:name":"Gutu",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/890/416/479/890416479.geojson
+++ b/data/890/416/479/890416479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.253678,
-    "geom:area_square_m":3004703015.275657,
+    "geom:area_square_m":3004703018.309734,
     "geom:bbox":"30.372837,-17.063172,30.979837,-16.338772",
     "geom:latitude":-16.68444,
     "geom:longitude":30.657949,
@@ -87,12 +87,13 @@
         "wd:id":"Q1708967",
         "wk:page":"Guruve District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"593f922f1684adccaa51ed07234dfdfb",
+    "wof:geomhash":"4e621208113b201a28d17770038a431f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":890416479,
-    "wof:lastmodified":1690930153,
+    "wof:lastmodified":1695886244,
     "wof:name":"Guruve",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/416/481/890416481.geojson
+++ b/data/890/416/481/890416481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.288318,
-    "geom:area_square_m":3354667361.013363,
+    "geom:area_square_m":3354667619.022504,
     "geom:bbox":"32.346537,-20.110272,33.061737,-19.371772",
     "geom:latitude":-19.783835,
     "geom:longitude":32.72148,
@@ -93,12 +93,13 @@
         "wd:id":"Q1073093",
         "wk:page":"Chimanimani District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7cdfbdd0a449948fb971c53b07218a81",
+    "wof:geomhash":"c9c45c390524d6956af6ddcc823837a3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":890416481,
-    "wof:lastmodified":1690930155,
+    "wof:lastmodified":1695886243,
     "wof:name":"Chimanimani",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/416/483/890416483.geojson
+++ b/data/890/416/483/890416483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.454943,
-    "geom:area_square_m":5345731541.524697,
+    "geom:area_square_m":5345731541.85697,
     "geom:bbox":"29.892837,-18.555572,30.830798,-17.822372",
     "geom:latitude":-18.143628,
     "geom:longitude":30.395096,
@@ -81,12 +81,13 @@
         "wd:id":"Q5089562",
         "wk:page":"Chegutu District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3749f9bf6973eff762bea5fa59333dcd",
+    "wof:geomhash":"1478c4a47433040dc1a267d771492f64",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890416483,
-    "wof:lastmodified":1690930153,
+    "wof:lastmodified":1695886243,
     "wof:name":"Chegutu",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/890/416/487/890416487.geojson
+++ b/data/890/416/487/890416487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.360901,
-    "geom:area_square_m":4280450416.289621,
+    "geom:area_square_m":4280450501.112326,
     "geom:bbox":"30.792937,-16.852072,31.511626,-15.984672",
     "geom:latitude":-16.425567,
     "geom:longitude":31.143765,
@@ -84,12 +84,13 @@
         "wd:id":"Q1709322",
         "wk:page":"Centenary District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"381b2e71d5015d51a3f0775f064d83b8",
+    "wof:geomhash":"7bbf2a43d687b8e2fa3f7337cc9b4673",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":890416487,
-    "wof:lastmodified":1627523021,
+    "wof:lastmodified":1695886243,
     "wof:name":"Centenary",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/416/489/890416489.geojson
+++ b/data/890/416/489/890416489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.556297,
-    "geom:area_square_m":6456871063.168842,
+    "geom:area_square_m":6456870741.00983,
     "geom:bbox":"26.702337,-20.516472,28.331737,-19.793072",
     "geom:latitude":-20.169223,
     "geom:longitude":27.574538,
@@ -78,12 +78,13 @@
         "wd:id":"Q4996407",
         "wk:page":"Bulilimamangwe District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cfc9571fa02da54b0eb73b978666868f",
+    "wof:geomhash":"29d81d3da586b96b56eac5a4da3ddc90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":890416489,
-    "wof:lastmodified":1690930156,
+    "wof:lastmodified":1695886243,
     "wof:name":"Bulilima",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/890/416/491/890416491.geojson
+++ b/data/890/416/491/890416491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.460906,
-    "geom:area_square_m":5373937647.054798,
+    "geom:area_square_m":5373937828.153932,
     "geom:bbox":"31.188571,-19.999368,32.396337,-19.011325",
     "geom:latitude":-19.448998,
     "geom:longitude":31.868271,
@@ -90,12 +90,13 @@
         "wd:id":"Q1002632",
         "wk:page":"Buhera District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ae1deffe30bf2cf8c336082b1379fefc",
+    "wof:geomhash":"29c4a1507b02ff77a3023c58473df628",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":890416491,
-    "wof:lastmodified":1690930154,
+    "wof:lastmodified":1695886243,
     "wof:name":"Buhera",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/416/493/890416493.geojson
+++ b/data/890/416/493/890416493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.523115,
-    "geom:area_square_m":6096841997.595745,
+    "geom:area_square_m":6096842082.056939,
     "geom:bbox":"27.940037,-19.999472,29.232937,-19.129572",
     "geom:latitude":-19.513945,
     "geom:longitude":28.685139,
@@ -90,12 +90,13 @@
         "wd:id":"Q4982301",
         "wk:page":"Bubi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051138,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3c420b985f7d62c9cd65d87d3294c5e0",
+    "wof:geomhash":"427b2f4548b24db0898b0a66091ae74e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":890416493,
-    "wof:lastmodified":1690930156,
+    "wof:lastmodified":1695886243,
     "wof:name":"Bubi",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/890/416/495/890416495.geojson
+++ b/data/890/416/495/890416495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.136585,
-    "geom:area_square_m":13381757320.550568,
+    "geom:area_square_m":13381757532.100014,
     "geom:bbox":"26.852437,-18.507772,28.251337,-16.878299",
     "geom:latitude":-17.790657,
     "geom:longitude":27.655693,
@@ -142,12 +142,13 @@
         "wd:id":"Q863750",
         "wk:page":"Binga District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051138,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b5ab7568f6f4666e8114f4a2f565f6d8",
+    "wof:geomhash":"e7fbaba712eab9cfc7638265d042a1e1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":890416495,
-    "wof:lastmodified":1690930156,
+    "wof:lastmodified":1695886053,
     "wof:name":"Binga",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/890/416/497/890416497.geojson
+++ b/data/890/416/497/890416497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190455,
-    "geom:area_square_m":2249117610.103598,
+    "geom:area_square_m":2249117478.518682,
     "geom:bbox":"31.116437,-17.643372,31.509837,-16.825472",
     "geom:latitude":-17.245761,
     "geom:longitude":31.308301,
@@ -84,12 +84,13 @@
         "wd:id":"Q1709315",
         "wk:page":"Bindura District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051138,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"193a15fb5f5dcff3415ae6249c3f2d87",
+    "wof:geomhash":"76ebf3fc267c23dee6d82f1895a16f4f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":890416497,
-    "wof:lastmodified":1690930154,
+    "wof:lastmodified":1695886243,
     "wof:name":"Bindura",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/416/499/890416499.geojson
+++ b/data/890/416/499/890416499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.447465,
-    "geom:area_square_m":5194470064.017587,
+    "geom:area_square_m":5194470333.218982,
     "geom:bbox":"31.403181,-20.582572,32.344937,-19.821272",
     "geom:latitude":-20.145256,
     "geom:longitude":31.912127,
@@ -90,12 +90,13 @@
         "wd:id":"Q4907418",
         "wk:page":"Bikita District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051138,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b30b7632662c82ef38eee9ba1b54b49b",
+    "wof:geomhash":"5d68675d2ddd6347ff595b5672a98a16",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":890416499,
-    "wof:lastmodified":1690930154,
+    "wof:lastmodified":1695886244,
     "wof:name":"Bikita",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/890/416/501/890416501.geojson
+++ b/data/890/416/501/890416501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.111687,
-    "geom:area_square_m":12753525327.48381,
+    "geom:area_square_m":12753524618.384617,
     "geom:bbox":"29.037937,-22.354872,31.113337,-21.269304",
     "geom:latitude":-21.907061,
     "geom:longitude":30.031837,
@@ -111,12 +111,13 @@
         "wd:id":"Q4881482",
         "wk:page":"Beitbridge District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051138,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b1b2f93df5a65bf41cb083686b45eb4a",
+    "wof:geomhash":"3c22d6b6e7540fe5a847d45a75a540ed",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":890416501,
-    "wof:lastmodified":1690930155,
+    "wof:lastmodified":1695886053,
     "wof:name":"Beitbridge",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/890/422/333/890422333.geojson
+++ b/data/890/422/333/890422333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.669684,
-    "geom:area_square_m":7858997283.700086,
+    "geom:area_square_m":7858997263.500712,
     "geom:bbox":"31.722237,-19.175472,32.605437,-17.597272",
     "geom:latitude":-18.362325,
     "geom:longitude":32.182674,
@@ -90,12 +90,13 @@
         "wd:id":"Q1783697",
         "wk:page":"Makoni District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051438,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f1e3d0c29ee93308a9a3c10ac599fe1e",
+    "wof:geomhash":"4a1e5d9e2c8c098e7a76e5b12c41022c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":890422333,
-    "wof:lastmodified":1690930147,
+    "wof:lastmodified":1695886244,
     "wof:name":"Makoni",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/422/337/890422337.geojson
+++ b/data/890/422/337/890422337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.727097,
-    "geom:area_square_m":8591958293.121424,
+    "geom:area_square_m":8591958221.387604,
     "geom:bbox":"29.332637,-17.859472,30.527437,-16.264972",
     "geom:latitude":-17.123188,
     "geom:longitude":30.012082,
@@ -90,12 +90,13 @@
         "wd:id":"Q6739880",
         "wk:page":"Makonde District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051438,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d04a204f7972493dd1bd8d7dd16ba8da",
+    "wof:geomhash":"dbb3ec3027760d4ecb4c4354a80aeab4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":890422337,
-    "wof:lastmodified":1690930147,
+    "wof:lastmodified":1695886244,
     "wof:name":"Makonde",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/890/428/875/890428875.geojson
+++ b/data/890/428/875/890428875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214077,
-    "geom:area_square_m":2483052456.603187,
+    "geom:area_square_m":2483052323.744198,
     "geom:bbox":"29.756537,-20.626872,30.461237,-19.934972",
     "geom:latitude":-20.27715,
     "geom:longitude":30.078685,
@@ -108,12 +108,13 @@
         "wd:id":"Q24235929",
         "wk:page":"Zvishavane District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051777,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d14997d95c716e7567688c675e438a1",
+    "wof:geomhash":"e6970487f538c07f411edc89321dddf6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":890428875,
-    "wof:lastmodified":1690930152,
+    "wof:lastmodified":1695886052,
     "wof:name":"Zvishavane",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/890/428/877/890428877.geojson
+++ b/data/890/428/877/890428877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214767,
-    "geom:area_square_m":2528705515.347436,
+    "geom:area_square_m":2528705478.418151,
     "geom:bbox":"31.051737,-18.15857,31.612419,-17.442219",
     "geom:latitude":-17.784862,
     "geom:longitude":31.338139,
@@ -87,12 +87,13 @@
         "wd:id":"Q3756018",
         "wk:page":"Goromonzi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051777,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"83ad75596a321ebce14c1524506db528",
+    "wof:geomhash":"11376b0d7c0c211c902684df1d537bc4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":890428877,
-    "wof:lastmodified":1690930152,
+    "wof:lastmodified":1695886244,
     "wof:name":"Goromonzi",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/890/428/879/890428879.geojson
+++ b/data/890/428/879/890428879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.306741,
-    "geom:area_square_m":3552901745.99275,
+    "geom:area_square_m":3552901680.341877,
     "geom:bbox":"30.142937,-21.018772,31.057818,-19.981272",
     "geom:latitude":-20.490388,
     "geom:longitude":30.575399,
@@ -81,12 +81,13 @@
         "wd:id":"Q5102586",
         "wk:page":"Chivi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051777,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5b51b6bce1c52b39ff2f3d34d6fcbe23",
+    "wof:geomhash":"a803025cb16f1e06a52ac70a0c2bb82f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890428879,
-    "wof:lastmodified":1690930152,
+    "wof:lastmodified":1695886244,
     "wof:name":"Chivi",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/890/428/881/890428881.geojson
+++ b/data/890/428/881/890428881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.515135,
-    "geom:area_square_m":17448827707.908813,
+    "geom:area_square_m":17448827871.829292,
     "geom:bbox":"30.944037,-22.420972,32.447491,-20.405472",
     "geom:latitude":-21.34701,
     "geom:longitude":31.683229,
@@ -129,12 +129,13 @@
         "wd:id":"Q5101881",
         "wk:page":"Chiredzi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051777,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9d5d56293b7ad11a8d1afd03cd99a999",
+    "wof:geomhash":"8e80f184c10692bb55205142f4102528",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":890428881,
-    "wof:lastmodified":1690930152,
+    "wof:lastmodified":1695886052,
     "wof:name":"Chiredzi",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/890/430/547/890430547.geojson
+++ b/data/890/430/547/890430547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.451874,
-    "geom:area_square_m":5233702639.886799,
+    "geom:area_square_m":5233702921.310812,
     "geom:bbox":"32.135537,-21.327272,32.874337,-19.912972",
     "geom:latitude":-20.496021,
     "geom:longitude":32.473755,
@@ -82,12 +82,13 @@
         "wd:id":"Q16798851",
         "wk:page":"Chipinge District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469051857,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9055d64ccdb06465e33ad799059eaed",
+    "wof:geomhash":"7320ff01165d100fedc4aa980ea376b7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":890430547,
-    "wof:lastmodified":1627523021,
+    "wof:lastmodified":1695886244,
     "wof:name":"Chipinge",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/436/413/890436413.geojson
+++ b/data/890/436/413/890436413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.218009,
-    "geom:area_square_m":2554319534.69339,
+    "geom:area_square_m":2554319666.727424,
     "geom:bbox":"32.394337,-18.965472,33.066837,-18.194972",
     "geom:latitude":-18.639273,
     "geom:longitude":32.708774,
@@ -87,12 +87,13 @@
         "wd:id":"Q11990288",
         "wk:page":"Mutasa District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052111,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0487db3cd042e55e533efd6a27df6733",
+    "wof:geomhash":"61809d5bc776926e0935c1f7dd97f8eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":890436413,
-    "wof:lastmodified":1690930150,
+    "wof:lastmodified":1695886245,
     "wof:name":"Mutasa",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/436/415/890436415.geojson
+++ b/data/890/436/415/890436415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.474535,
-    "geom:area_square_m":5540231082.553164,
+    "geom:area_square_m":5540231076.58037,
     "geom:bbox":"32.015437,-19.772472,32.884737,-18.725872",
     "geom:latitude":-19.231394,
     "geom:longitude":32.423755,
@@ -75,12 +75,13 @@
         "wd:id":"Q5095143",
         "wk:page":"Chiadzwa"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052111,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"efd509d16d6e9a33743feba45e8349d2",
+    "wof:geomhash":"dacb4b00ff7cfd36700f164456a0fc9d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":890436415,
-    "wof:lastmodified":1636502216,
+    "wof:lastmodified":1695886052,
     "wof:name":"Mutare",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/436/773/890436773.geojson
+++ b/data/890/436/773/890436773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.150344,
-    "geom:area_square_m":13246511638.795473,
+    "geom:area_square_m":13246511847.847527,
     "geom:bbox":"29.726637,-22.112833,31.608037,-20.682312",
     "geom:latitude":-21.365429,
     "geom:longitude":30.691748,
@@ -84,12 +84,13 @@
         "wd:id":"Q15260492",
         "wk:page":"Mwenezi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052125,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"20229183f7be2dda689004c10aeec836",
+    "wof:geomhash":"4ba24834c758c8db399a262c6c10272d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":890436773,
-    "wof:lastmodified":1690930151,
+    "wof:lastmodified":1695886245,
     "wof:name":"Mwenezi",
     "wof:parent_id":85681127,
     "wof:placetype":"county",

--- a/data/890/445/295/890445295.geojson
+++ b/data/890/445/295/890445295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.291737,
-    "geom:area_square_m":3425504339.810192,
+    "geom:area_square_m":3425504076.54931,
     "geom:bbox":"30.999537,-18.603428,31.863424,-17.900472",
     "geom:latitude":-18.270918,
     "geom:longitude":31.497797,
@@ -75,12 +75,13 @@
         "wd:id":"Q16894719",
         "wk:page":"Marondera District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052504,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"30f09293f4a240b6ae5b48aa3a1f9649",
+    "wof:geomhash":"bcebb3b7e5d3adc3524063e0e920e719",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":890445295,
-    "wof:lastmodified":1690930157,
+    "wof:lastmodified":1695886245,
     "wof:name":"Marondera",
     "wof:parent_id":85681109,
     "wof:placetype":"county",

--- a/data/890/450/097/890450097.geojson
+++ b/data/890/450/097/890450097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.240429,
-    "geom:area_square_m":2787479366.069077,
+    "geom:area_square_m":2787479414.438152,
     "geom:bbox":"28.657937,-20.699172,29.231737,-19.956772",
     "geom:latitude":-20.344685,
     "geom:longitude":28.945571,
@@ -84,12 +84,13 @@
         "wd:id":"Q6038184",
         "wk:page":"Insiza (District)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052725,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3e7a0c55854a7e4db6bb348c1414d1ca",
+    "wof:geomhash":"e6177de8a4e72fc719977b5c559c4b55",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":890450097,
-    "wof:lastmodified":1690930158,
+    "wof:lastmodified":1695886801,
     "wof:name":"Umzingwane",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/890/450/099/890450099.geojson
+++ b/data/890/450/099/890450099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.298559,
-    "geom:area_square_m":3474560460.798256,
+    "geom:area_square_m":3474560703.602508,
     "geom:bbox":"29.786837,-20.071772,30.487737,-19.415772",
     "geom:latitude":-19.750236,
     "geom:longitude":30.152952,
@@ -81,12 +81,13 @@
         "wd:id":"Q7505444",
         "wk:page":"Shurugwi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052725,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d305eeb856f16edba73b88eed530beca",
+    "wof:geomhash":"bf3aa91dbb49c64acda99564e720c28b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890450099,
-    "wof:lastmodified":1690930158,
+    "wof:lastmodified":1695886245,
     "wof:name":"Shurugwi",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/890/450/101/890450101.geojson
+++ b/data/890/450/101/890450101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.228756,
-    "geom:area_square_m":2703634812.945108,
+    "geom:area_square_m":2703635057.185186,
     "geom:bbox":"31.344737,-17.509153,32.009737,-16.818572",
     "geom:latitude":-17.094634,
     "geom:longitude":31.638904,
@@ -117,12 +117,13 @@
         "wd:id":"Q1756329",
         "wk:page":"Shamva District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052726,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ce9f9882d355e133955076528e6ef332",
+    "wof:geomhash":"4cf32326dfcd3e142d845b12418e6ced",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":890450101,
-    "wof:lastmodified":1690930159,
+    "wof:lastmodified":1695886053,
     "wof:name":"Shamva",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/450/103/890450103.geojson
+++ b/data/890/450/103/890450103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.196906,
-    "geom:area_square_m":2333203869.862581,
+    "geom:area_square_m":2333203923.592741,
     "geom:bbox":"31.907437,-16.809472,32.756437,-16.430872",
     "geom:latitude":-16.607714,
     "geom:longitude":32.295205,
@@ -81,12 +81,13 @@
         "wd:id":"Q1708960",
         "wk:page":"Rushinga District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052726,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd25017a201a5f5bee1b9d6cd8336192",
+    "wof:geomhash":"f198deffb8143fc76b4375837e03ca7d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890450103,
-    "wof:lastmodified":1690930158,
+    "wof:lastmodified":1695886246,
     "wof:name":"Rushinga",
     "wof:parent_id":85681093,
     "wof:placetype":"county",

--- a/data/890/450/105/890450105.geojson
+++ b/data/890/450/105/890450105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.492974,
-    "geom:area_square_m":5799317696.002316,
+    "geom:area_square_m":5799318070.137686,
     "geom:bbox":"32.380237,-18.576672,33.053037,-17.245672",
     "geom:latitude":-17.937935,
     "geom:longitude":32.757786,
@@ -84,12 +84,13 @@
         "wd:id":"Q7070875",
         "wk:page":"Nyanga District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052726,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4028955c3894244ed1c2e0b822c4d5ae",
+    "wof:geomhash":"ac94666cf9acd93c43fc33371682c935",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":890450105,
-    "wof:lastmodified":1690930158,
+    "wof:lastmodified":1695886053,
     "wof:name":"Nyanga",
     "wof:parent_id":85681113,
     "wof:placetype":"county",

--- a/data/890/450/107/890450107.geojson
+++ b/data/890/450/107/890450107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.414144,
-    "geom:area_square_m":4845319871.934958,
+    "geom:area_square_m":4845319595.723295,
     "geom:bbox":"28.289837,-19.296072,29.128937,-18.550772",
     "geom:latitude":-18.883567,
     "geom:longitude":28.661198,
@@ -75,12 +75,13 @@
         "wd:id":"Q15262423",
         "wk:page":"Nkayi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052726,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bfd44a613ae53555ef5fd6e2f7285073",
+    "wof:geomhash":"22827aa6ce73f99012bd7753f6478cfa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":890450107,
-    "wof:lastmodified":1627523024,
+    "wof:lastmodified":1695886246,
     "wof:name":"Nkayi",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/890/452/761/890452761.geojson
+++ b/data/890/452/761/890452761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.629042,
-    "geom:area_square_m":7263625145.871857,
+    "geom:area_square_m":7263625334.63732,
     "geom:bbox":"28.183737,-21.716272,28.78522,-20.221972",
     "geom:latitude":-20.954871,
     "geom:longitude":28.490923,
@@ -96,12 +96,13 @@
         "wd:id":"Q4790876",
         "wk:page":"Thuli River"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052828,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2f28f8a21be724e0a22de633b76d03bc",
+    "wof:geomhash":"0a6d074fe30938188247e5cbf8059c94",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890452761,
-    "wof:lastmodified":1690930149,
+    "wof:lastmodified":1695886245,
     "wof:name":"Matobo",
     "wof:parent_id":85681117,
     "wof:placetype":"county",

--- a/data/890/452/765/890452765.geojson
+++ b/data/890/452/765/890452765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.866283,
-    "geom:area_square_m":10137790081.299156,
+    "geom:area_square_m":10137790966.841244,
     "geom:bbox":"27.036037,-19.501472,28.436937,-18.237172",
     "geom:latitude":-18.839155,
     "geom:longitude":27.793259,
@@ -112,12 +112,13 @@
         "wd:id":"Q997614",
         "wk:page":"Lupane District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052828,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0e2dad40fea84a02baaa3fa1894e6058",
+    "wof:geomhash":"16c9ac47bee99bd815f649b7ca238e56",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":890452765,
-    "wof:lastmodified":1690930148,
+    "wof:lastmodified":1695886801,
     "wof:name":"Lupane",
     "wof:parent_id":85681101,
     "wof:placetype":"county",

--- a/data/890/452/767/890452767.geojson
+++ b/data/890/452/767/890452767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.750046,
-    "geom:area_square_m":8775497771.077597,
+    "geom:area_square_m":8775497960.939079,
     "geom:bbox":"28.867288,-19.372822,30.382537,-18.269372",
     "geom:latitude":-18.878827,
     "geom:longitude":29.551837,
@@ -96,12 +96,13 @@
         "wd:id":"Q6450306",
         "wk:page":"Kwekwe District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052829,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bf5ded0e7ee049c9979ccd13a3dd2e56",
+    "wof:geomhash":"f565198ddeef77bf0a6a3b8e131cadfa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890452767,
-    "wof:lastmodified":1690930149,
+    "wof:lastmodified":1695886052,
     "wof:name":"Kwekwe",
     "wof:parent_id":85681103,
     "wof:placetype":"county",

--- a/data/890/452/769/890452769.geojson
+++ b/data/890/452/769/890452769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.694724,
-    "geom:area_square_m":8219678980.308636,
+    "geom:area_square_m":8219679196.32469,
     "geom:bbox":"28.013937,-17.413972,29.214337,-16.365672",
     "geom:latitude":-16.892259,
     "geom:longitude":28.61079,
@@ -120,12 +120,13 @@
         "wd:id":"Q2139155",
         "wk:page":"Kariba (District)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052829,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3c27a6a2c0ff83055fba5e94cc8ff457",
+    "wof:geomhash":"e49f0694467d26c6f828bb033a3d7500",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":890452769,
-    "wof:lastmodified":1690930149,
+    "wof:lastmodified":1695886052,
     "wof:name":"Kariba",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/890/452/771/890452771.geojson
+++ b/data/890/452/771/890452771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021687,
-    "geom:area_square_m":254538298.109484,
+    "geom:area_square_m":254538305.310532,
     "geom:bbox":"29.781737,-18.417872,30.026937,-18.224872",
     "geom:latitude":-18.339091,
     "geom:longitude":29.928363,
@@ -81,12 +81,13 @@
         "wd:id":"Q6345648",
         "wk:page":"Kadoma District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052829,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eec498c4b4e58c29b353062e0a692774",
+    "wof:geomhash":"ab57127e4412f9f00f4c5a38b9e5c770",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890452771,
-    "wof:lastmodified":1690930148,
+    "wof:lastmodified":1695886245,
     "wof:name":"Kadoma Urban",
     "wof:parent_id":85681131,
     "wof:placetype":"county",

--- a/data/890/452/775/890452775.geojson
+++ b/data/890/452/775/890452775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.710739,
-    "geom:area_square_m":8244642641.747546,
+    "geom:area_square_m":8244642989.316792,
     "geom:bbox":"28.955037,-21.056172,29.874537,-19.481872",
     "geom:latitude":-20.257888,
     "geom:longitude":29.405108,
@@ -81,12 +81,13 @@
         "wd:id":"Q6038184",
         "wk:page":"Insiza (District)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ZW",
     "wof:created":1469052829,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5330244e72d190df4e1cb96620d4cd58",
+    "wof:geomhash":"85f82a8356636f263cff1234fb23e2ae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":890452775,
-    "wof:lastmodified":1690930150,
+    "wof:lastmodified":1695886801,
     "wof:name":"Insiza",
     "wof:parent_id":85681117,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.